### PR TITLE
fixed a bug

### DIFF
--- a/poxdesk/source/class/poxdesk/TopoViewer.js
+++ b/poxdesk/source/class/poxdesk/TopoViewer.js
@@ -162,7 +162,7 @@ this._edges = {};
         {
           var dead = dead_edge_names[edge_name];
           this.graph.removeEdge(dead);
-          delete this._edges[dead];
+          delete this._edges[edge_name];
         }
 
       }


### PR DESCRIPTION
When a link fails, it is not deleted properly. So TopoViewer won't show the link when it is up again.
